### PR TITLE
Add option to output to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,50 @@ When started, it does the following:
 - Creates a STAC item with assets. The assets `href` is based on the given URL.
 - Adds the STAC item to a STAC catalog. If an item with the same id already exists, it will be updated.
 
+## Installation
+
+Install the package using pip:
+
+```bash
+# Install from source
+pip install .
+
+# Or install in editable mode for development
+pip install -e .
+```
+
+After installation, the `eopf-stac` command will be available in your environment.
+
 ## Usage
 
 The EOPF product must be referenced by an URL which must be provided as a command-line argument. Only `http(s)://`, `s3://` and `file://` URLs are supported. For debugging, a combination of the `--dry-run` and `--debug` option can be used to see the created STAC item in the logs without inserting it into a catalog.
 
 ```bash
-$ python src/eopf_stac/main.py --help
-usage: eopf-stac.py [-h] [--dry-run] [--debug] URL
+$ eopf-stac --help
+usage: eopf-stac.py [-h] [--source-uri SOURCE_URI] [--dry-run] [--debug] URL
 
 positional arguments:
-  URL         Local file path or HTTP/S3 URL to the EOPF product.
+  URL         Local file path or URL to the EOPF product
 
 options:
-  -h, --help   show this help message and exit  
-  --source-uri SOURCE_URI Reference to the original product which was input for the EOPF conversion
-  --dry-run    Create STAC item only. Do not insert it into the catalog
+  -h, --help   show this help message and exit
+  --source-uri SOURCE_URI
+               Reference to the original product which was input for the EOPF conversion
+  --dry-run    Create STAC item without trying to insert it into the catalog
   --debug      Enable verbose output
+```
+
+Example usage:
+
+```bash
+# Process an EOPF product from S3
+eopf-stac s3://path/to/eopf.zarr
+
+# Dry run with debug output
+eopf-stac --dry-run --debug s3://path/to/eopf.zarr
+
+# With source URI
+eopf-stac --source-uri s3://original/product.nc s3://path/to/eopf.zarr
 ```
 
 ## Settings 

--- a/README.md
+++ b/README.md
@@ -27,26 +27,31 @@ The EOPF product must be referenced by an URL which must be provided as a comman
 
 ```bash
 $ eopf-stac --help
-usage: eopf-stac.py [-h] [--source-uri SOURCE_URI] [--dry-run] [--debug] URL
+usage: eopf-stac.py [-h] [--source-uri SOURCE_URI] [--dry-run] [--output-file OUTPUT_FILE] [--debug] URL
 
 positional arguments:
   URL         Local file path or URL to the EOPF product
 
 options:
-  -h, --help   show this help message and exit
+  -h, --help            show this help message and exit
   --source-uri SOURCE_URI
-               Reference to the original product which was input for the EOPF conversion
-  --dry-run    Create STAC item without trying to insert it into the catalog
-  --debug      Enable verbose output
+                        Reference to the original product which was input for the EOPF conversion
+  --dry-run             Create STAC item without trying to insert it into the catalog
+  --output-file OUTPUT_FILE
+                        Save the STAC item as JSON to the specified file path
+  --debug               Enable verbose output
 ```
 
 Example usage:
 
 ```bash
-# Process an EOPF product from S3
+# Register STAC item to catalog
 eopf-stac s3://path/to/eopf.zarr
 
-# Dry run with debug output
+# Save STAC item to local file instead of registering
+eopf-stac --output-file item.json s3://path/to/eopf.zarr
+
+# Dry run with debug output (only logs, doesn't save or register)
 eopf-stac --dry-run --debug s3://path/to/eopf.zarr
 
 # With source URI
@@ -62,7 +67,7 @@ Additional settings need to be provided through the following environment variab
 | AWS_ACCESS_KEY_ID | If an s3 URL is provided, the access key for the object storage where the EOPF product is stored. | None |
 | AWS_SECRET_ACCESS_KEY | If an s3 URL is provided, the secret for the access key. | None |
 | S3_ENDPOINT_URL | If an s3 URL is provided, the endpoint URL of the object storage  | None |
-| STAC_API_URL | The URL of the STAC catalog to register the created STAC item  | None |
+| STAC_API_URL | The URL of the STAC catalog to register the created STAC item. Not required if `--output-file` is used. | None |
 | STAC_INGEST_USER | The username to access the transaction endpoints of the STAC API with HTTP Basic Auth | None |
 | STAC_INGEST_PASS | The password to access the transaction endpoints of the STAC API with HTTP Basic Auth | None |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
     "netCDF4 == 1.7.2",
     "footprint-facility"
 ]
+[project.scripts]
+eopf-stac = "eopf_stac.main:main"
+
 [project.optional-dependencies]
 dev = [
     "ruff"


### PR DESCRIPTION
## What I'm changing

The tool currently only outputs the STAC JSON by registering it to a STAC API.

I'm proposing to add an option to write to a local JSON file, alternatively.

NOTE: This PR also includes the change from
- #64 

I'll rebase when the other one gets accepted, hopefully.

## How I did it

- [x] Added an `--output-file` flag and adjusted the env var validation logic
- [x] Updated README

## How you can test it

```bash
eopf-stac /path/to/source.zarr --output-file /path/to/item.json
```

Note that `STAC_API_URL` is not required in this case.